### PR TITLE
Fix #5

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "postcss-clean": "1.1.0",
     "postcss-cli": "6.1.2",
     "postcss-import": "12.0.1",
+    "postcss-inset": "1.0.0",
     "postcss-preset-env": "6.6.0",
     "postcss-pseudo-class-enter": "5.0.0",
     "stylelint-selector-bem-pattern": "2.1.0",

--- a/src/_includes/css/app.css
+++ b/src/_includes/css/app.css
@@ -43,11 +43,11 @@ body {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-around;
+  align-items: center;
 
   @media (--mq-m) {
     flex-wrap: initial;
     justify-content: space-between;
-    align-items: center;
   }
 }
 

--- a/src/theme.js
+++ b/src/theme.js
@@ -6,7 +6,7 @@ const breakpoints = {
 };
 
 /**
- * Produces an object of media queries from `breakpoints` suitable for use in 
+ * Produces an object of media queries from `breakpoints` suitable for use in
  * matchMedia queries in JS
  *
  * {
@@ -27,7 +27,7 @@ const mediaQueries = Object.entries(breakpoints).reduce((acc, [k, v]) => {
  *   --mq-l:  (min-width: 960px),
  *   --mq-xl: (min-width: 1200px)
  * }
- * 
+ *
  * usage:
  * .app {
  *   @media (--mq-m) { ... }
@@ -35,14 +35,11 @@ const mediaQueries = Object.entries(breakpoints).reduce((acc, [k, v]) => {
  *   @media (--mq-xl) { ... }
  * }
  */
-const customMedia = Object.entries(mediaQueries).reduce(
-  (acc, [k, v]) => {
-    return { ...acc, [`--mq-${k}`]: v };
-  },
-  {}
-);
+const customMedia = Object.entries(mediaQueries).reduce((acc, [k, v]) => {
+  return { ...acc, [`--mq-${k}`]: v };
+}, {});
 
 module.exports = {
   mediaQueries,
   customMedia
-}
+};

--- a/tools/postcss.config.js
+++ b/tools/postcss.config.js
@@ -2,6 +2,7 @@
 const postcssPseudoEnter = require("postcss-pseudo-class-enter");
 const postcssPresetEnv = require(`postcss-preset-env`);
 const postcssClean = require(`postcss-clean`);
+const postcssInset = require(`postcss-inset`);
 
 const { customMedia } = require("../src/theme.js");
 
@@ -16,6 +17,7 @@ module.exports = () => ({
         "custom-media-queries": { importFrom: { customMedia } }
       }
     }),
+    postcssInset(),
     postcssPseudoEnter(),
     postcssClean()
   ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5091,6 +5091,13 @@ postcss-initial@^3.0.0:
     lodash.template "^4.2.4"
     postcss "^7.0.2"
 
+postcss-inset@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-inset/-/postcss-inset-1.0.0.tgz#1bc0937996a5f042f7054643dbf8f60e49065fa7"
+  integrity sha512-GAGG8dCDL8zq3BLo2spfcY7YxVQzIZscHDklcJVy/VI2V5lO8V5N9b/p96411w8nf40v7lx3VOiAzBNJlmrI4Q==
+  dependencies:
+    postcss "^6.0.1"
+
 postcss-jsx@^0.36.0:
   version "0.36.0"
   resolved "https://registry.yarnpkg.com/postcss-jsx/-/postcss-jsx-0.36.0.tgz#b7685ed3d070a175ef0aa48f83d9015bd772c82d"
@@ -5352,7 +5359,7 @@ postcss@7.0.14, postcss@>=5.0.19, postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.1
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^6.x:
+postcss@^6.0.1, postcss@^6.x:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
   integrity sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==


### PR DESCRIPTION
- Adds centre alignment to the `.row` utility class
- Adds `postcss-inset` to allow use of the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property, which provides a handy shorthand syntax for logical block and inline start and end offsets... but is currently only supported by Firefox