### PR TITLE
Add config for VSCode integration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "cpylua.language-postcss",
+    "esbenp.prettier-vscode",
+    "mblode.twig-language-2",
+    "shinnn.stylelint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,7 +11,6 @@
 
   "emmet.includeLanguages": {
     "twig": "html",
-    "javascript": "javascriptreact",
     "postcss": "css"
   },
   "emmet.syntaxProfiles": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,25 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+
+  "files.associations": {
+    "*.css": "postcss",
+    "*.njk": "twig",
+    ".stylelintrc": "json"
+  },
+
+  "eslint.options": { "configFile": "./tools/.eslintrc" },
+
+  "emmet.includeLanguages": {
+    "twig": "html",
+    "javascript": "javascriptreact",
+    "postcss": "css"
+  },
+  "emmet.syntaxProfiles": {
+    "twig": "html",
+    "postcss": "css"
+  },
+
+  "prettier.stylelintIntegration": true,
+
+  "stylelint.config": { "extends": "./tools/.stylelintrc" }
+}


### PR DESCRIPTION
This codebase reflects my own workflow and tooling choices. In order for others to find it easier to contribute a list of recommended plugins and settings has been added.

The suggested plugins should make it easier to read and write code without false-positive syntax violations being reported by the.

Config for eslint and stylelint is found under `./tools`: the `.vscode/settings.json` tells VSCode where to find them so that developers get instant feedback rather than only when the linters are run (e.g. on commit)