### PR TITLE
Fix link to twitch channel

### DIFF
--- a/src/events/event3.njk
+++ b/src/events/event3.njk
@@ -5,7 +5,7 @@ tags:
 title: "Event 3"
 subtitle: "2020 vision"
 description: |
-  Please join us on our brand new [Twitch channel](www.twitch.tv/londoncss) for another evening of talks!
+  Please join us on our brand new [Twitch channel](https://www.twitch.tv/londoncss) for another evening of talks!
 layout: "layouts/event.njk"
 event:
   registerUrl: "https://www.eventbrite.co.uk/e/london-css-march-2020-registration-95887400797"


### PR DESCRIPTION
It was linking to https://www.londoncss.dev/www.twitch.tv/londoncss